### PR TITLE
gemspec: Allow Bundler 2, rake >= 12.3.3

### DIFF
--- a/banktools-gb.gemspec
+++ b/banktools-gb.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "attr_extras"
 
-  spec.add_development_dependency "bundler", "~> 1"
-  spec.add_development_dependency "rake", "~> 11"
+  spec.add_development_dependency "bundler", ">= 1"
+  spec.add_development_dependency "rake", ">= 12.3.3"
   spec.add_development_dependency "rspec", "~> 3"
 end


### PR DESCRIPTION
This PR avoids a GitHub security advisory, and lets developers use Bundler 2. (The last part's only troubling if we'd have a checked-in `Gemfile.lock`, which we don't.)